### PR TITLE
Allow users to run multiple configs at once

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,6 +33,9 @@ To start or switch to a session use::
 
   pytmux run
 
+You can provider a list of configs to run.  Pytmux will run then in turn and
+the last one will end up on the screen.
+
 doctor
 ~~~~~~
 

--- a/pytmux/cli.py
+++ b/pytmux/cli.py
@@ -2,7 +2,7 @@
 
 Usage:
   pytmux list
-  pytmux run <config>
+  pytmux run <config>...
   pytmux edit <config> [--copy <other_config>]
   pytmux doctor
   pytmux -h | --help
@@ -10,7 +10,7 @@ Usage:
 
 Commands:
   list            Lists all configs.
-  run <config>    Runs the specified config.
+  run <config>... Runs the specified config.
   edit <config>   Edits the specified config, with --copy will make a new
                   config based on the one specified.
   doctor          Validates all of you configs.
@@ -38,7 +38,8 @@ def main():
     if arguments['list']:
         list_configs()
     elif arguments['run']:
-        run_config(arguments['<config>'])
+        for config in arguments['<config>']:
+            run_config(config)
     elif arguments['edit']:
         edit_config(arguments['<config>'], arguments['--copy'],
                     arguments['<other_config>'])

--- a/pytmux/cli.py
+++ b/pytmux/cli.py
@@ -10,7 +10,8 @@ Usage:
 
 Commands:
   list            Lists all configs.
-  run <config>... Runs the specified config.
+  run <config>... Runs the specified config.  The last config will end
+                  up on the screen.
   edit <config>   Edits the specified config, with --copy will make a new
                   config based on the one specified.
   doctor          Validates all of you configs.


### PR DESCRIPTION
I have about 10 configs in my `$HOME/.pytmux`. After a reboot, I like to run them all. Instead of one by one, I want to be able to run them all at once.

```
$ pytmux run mail irc python
```

This pull request accomplishes that.
